### PR TITLE
Add new possibile configurations for image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This image supports some environment variables:
 
 * `USERNAME`: Username needed for turn. Defaults to `username`
 * `PASSWORD`: Password needed for turn. Defaults ro `password`
+* `SHARED_SECRET`: To enable credentials generation from a third part server
+* `VERBOSE`: to enable log in verbose mode
 * `REALM`: Realm needed for turn. Defaults to `realm`
 * `MIN_PORT`: This defines the min-port for the range used by turn. Defaults to `65435`
 * `MAX_PORT`: This defines the max-port for the range used by turn. Defaults to `65535`

--- a/deploy-turnserver.sh
+++ b/deploy-turnserver.sh
@@ -28,6 +28,10 @@ if [ -n "$SHARED_SECRET" ]; then
     echo "static-auth-secret=$SHARED_SECRET" >> /etc/turnserver.conf
 fi
 
+if [ "$VERBOSE" == "true" ];then
+    echo "verbose" >> /etc/turnserver.conf
+fi
+
 turnadmin -a -u $USERNAME -p $PASSWORD -r $REALM
 
 echo "Start TURN server..."

--- a/deploy-turnserver.sh
+++ b/deploy-turnserver.sh
@@ -2,6 +2,8 @@ echo "USERNAME: $USERNAME"
 echo "PASSWORD: $PASSWORD"
 echo "REALM: $REALM"
 echo "PORT RANGE: $MIN_PORT-$MAX_PORT"
+echo "SHARED_SECRET: $SHARED_SECRET"
+echo "VERBOSE: $VERBOSE"
 
 internalIp="$(ip a | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')"
 externalIp="$(dig +short myip.opendns.com @resolver1.opendns.com)"

--- a/deploy-turnserver.sh
+++ b/deploy-turnserver.sh
@@ -23,6 +23,11 @@ pkey=/etc/ssl/turn_server_pkey.pem
  
 no-stdout-log"  | tee /etc/turnserver.conf
 
+if [ -n "$SHARED_SECRET" ]; then
+    echo "use-auth-secret" >> /etc/turnserver.conf
+    echo "static-auth-secret=$SHARED_SECRET" >> /etc/turnserver.conf
+fi
+
 turnadmin -a -u $USERNAME -p $PASSWORD -r $REALM
 
 echo "Start TURN server..."


### PR DESCRIPTION
In this patch, two new configurations are allowed:

- To configure shared secret to allow the server to auto-generate credentials like you can see it here:
https://localcoder.org/coturn-how-to-use-turn-rest-api#solution_2

- Enable log verbose by adding environment variable
```
docker run
...
-e "VERBOSE=true"
```